### PR TITLE
Optimization

### DIFF
--- a/tms-ts/src/components/testcases/creation.case.component.tsx
+++ b/tms-ts/src/components/testcases/creation.case.component.tsx
@@ -8,13 +8,12 @@ import React, {useEffect, useState} from "react";
 import useStyles from "../../styles/styles";
 import {Grid, Button, Dialog, TextField, Typography} from "@mui/material";
 import SuiteCaseService from "../../services/suite.case.service";
-import {CustomWidthTooltip, myCase, suite, treeSuite} from "./suites.component";
+import {CustomWidthTooltip, myCase, treeSuite} from "./suites.component";
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 
 interface Props {
     show: boolean;
     setShow: (show: boolean) => void;
-    suites: suite [];
     selectedSuiteCome: { id: number, name: string } | null;
     setTreeSuites: (treeSuites: treeSuite[]) => void;
     infoCaseForEdit: myCase | null;
@@ -22,14 +21,13 @@ interface Props {
     setDetailedCaseInfo: (myCase: { show: boolean, myCase: myCase }) => void,
     detailedCaseInfo: { show: boolean, myCase: myCase },
     setLastEditCase: (id: number) => void,
-    setSelectedSuiteForTreeView : (suite: treeSuite) => void,
+    setSelectedSuiteForTreeView: (suite: treeSuite) => void,
     selectedSuiteForTreeView: treeSuite
 }
 
 const CreationCase: React.FC<Props> = ({
                                            show,
                                            setShow,
-                                           suites,
                                            selectedSuiteCome,
                                            infoCaseForEdit,
                                            setInfoCaseForEdit,
@@ -40,12 +38,9 @@ const CreationCase: React.FC<Props> = ({
                                            selectedSuiteForTreeView
                                        }) => {
     const classes = useStyles()
-    const [selectedSuite, setSelectedSuite] = useState<{ id: number; name: string }>(suites.length > 0 ? {
-        id: suites[0].id,
-        name: suites[0].name,
-    } : {
-        id: -1,
-        name: "Нет допустимых сьют",
+    const [selectedSuite, setSelectedSuite] = useState<{ id: number; name: string }>({
+        id: selectedSuiteForTreeView.id,
+        name: selectedSuiteForTreeView.name,
     })
 
     const [name, setName] = useState("")
@@ -63,7 +58,22 @@ const CreationCase: React.FC<Props> = ({
     const [setup, setSetup] = useState("")
     const [teardown, setTeardown] = useState("")
 
+    const [suitesForSelect, setSuitesForSelect] = useState<{ id: number, name: string }[] | treeSuite[]>([])
+
+
     useEffect(() => {
+        const suitesForSelect: { id: number, name: string }[] = []
+        const fillSuitesForSelect = (childrenSuitesArr: treeSuite[]) => {
+            childrenSuitesArr.map((suite) => {
+                suitesForSelect.push({id: suite.id, name: suite.name})
+                if (suite.children.length > 0) {
+                    fillSuitesForSelect(suite.children)
+                }
+            })
+        }
+        suitesForSelect.push({id: selectedSuiteForTreeView.id, name: selectedSuiteForTreeView.name})
+        fillSuitesForSelect(selectedSuiteForTreeView.children)
+        setSuitesForSelect(suitesForSelect)
         if (selectedSuiteCome) {
             setSelectedSuite(selectedSuiteCome)
         }
@@ -162,9 +172,9 @@ const CreationCase: React.FC<Props> = ({
             }
             if (infoCaseForEdit) {
                 SuiteCaseService.editCase({...myCase, url: infoCaseForEdit.url, id: infoCaseForEdit.id}).then(() => {
-                   SuiteCaseService.getTreeBySetSuite(selectedSuiteForTreeView.id).then((response)=>{
-                       setSelectedSuiteForTreeView(response.data)
-                   })
+                    SuiteCaseService.getTreeBySetSuite(selectedSuiteForTreeView.id).then((response) => {
+                        setSelectedSuiteForTreeView(response.data)
+                    })
                 })
                 if (infoCaseForEdit.id === detailedCaseInfo.myCase.id && detailedCaseInfo.show) {
                     setLastEditCase(infoCaseForEdit.id)
@@ -172,7 +182,7 @@ const CreationCase: React.FC<Props> = ({
                 }
             } else {
                 SuiteCaseService.createCase(myCase).then(() => {
-                    SuiteCaseService.getTreeBySetSuite(selectedSuiteForTreeView.id).then((response)=>{
+                    SuiteCaseService.getTreeBySetSuite(selectedSuiteForTreeView.id).then((response) => {
                         setSelectedSuiteForTreeView(response.data)
                     })
                 })
@@ -330,8 +340,8 @@ const CreationCase: React.FC<Props> = ({
                                     renderValue={(selected) => <Grid>{selected}</Grid>}
                                     MenuProps={MenuProps}
                                 >
-                                    {suites.map((suite, index) => <MenuItem key={index}
-                                                                            value={suite as any}>{suite.name}</MenuItem>)}
+                                    {suitesForSelect.map((suite, index) => <MenuItem key={index}
+                                                                                     value={suite as any}>{suite.name}</MenuItem>)}
                                 </Select>
                             </FormControl>
                         </Grid>

--- a/tms-ts/src/components/testcases/deletion.dialog.element.component.tsx
+++ b/tms-ts/src/components/testcases/deletion.dialog.element.component.tsx
@@ -55,9 +55,6 @@ function DeletionDialogElement(props: {
                         }
                     })
                 }
-                // SuiteCaseService.getTreeSuites().then((response) => {
-                //     setTreeSuites(response.data)
-                // })
                 SuiteCaseService.getTreeBySetSuite(selectedSuiteForTreeView.id).then((response) => {
                     setSelectedSuiteForTreeView(response.data)
                 }).catch((e) => {

--- a/tms-ts/src/components/testcases/folder.suites.component.tsx
+++ b/tms-ts/src/components/testcases/folder.suites.component.tsx
@@ -1,7 +1,7 @@
 import {IconButton, TextField} from "@mui/material";
 import Typography from '@mui/material/Typography';
 import React, {useEffect, useState} from "react";
-import {suite, treeSuite} from "./suites.component";
+import {treeSuite} from "./suites.component";
 import TreeView from "@mui/lab/TreeView";
 import TreeItem, {TreeItemContentProps, useTreeItem} from "@mui/lab/TreeItem";
 import SvgIcon from "@mui/material/SvgIcon";
@@ -150,10 +150,9 @@ const Suite = (props: {
 }
 
 const FolderSuites = (props: {
-    treeSuites: treeSuite | undefined,
-    suites: suite []
+    selectedSuiteForTreeView: treeSuite | undefined
 }) => {
-    const {treeSuites, suites} = props;
+    const {selectedSuiteForTreeView} = props;
     const [expanded, setExpanded] = useState<string[]>([])
     const [selected, setSelected] = useState<string[]>([])
     const [currentSuiteNumber, setCurrentSuiteNumber] = useState<number>(0)
@@ -167,7 +166,7 @@ const FolderSuites = (props: {
 
     useEffect(() => {
         const suitesIdArray: string[] = []
-        if (treeSuites){
+        if (selectedSuiteForTreeView) {
             const fillExpandedSuite = (childrenSuitesArr: treeSuite[]) => {
                 childrenSuitesArr.map((suite) => {
                     if (suite.children.length > 0) {
@@ -176,15 +175,30 @@ const FolderSuites = (props: {
                     suitesIdArray.push(suite.id.toString())
                 })
             }
-            suitesIdArray.push(treeSuites.id.toString())
-            fillExpandedSuite(treeSuites.children)
+            suitesIdArray.push(selectedSuiteForTreeView.id.toString())
+            fillExpandedSuite(selectedSuiteForTreeView.children)
         }
         setExpanded(suitesIdArray)
-    }, [treeSuites]);
+    }, [selectedSuiteForTreeView]);
 
     const onChangeName = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-        if (e.target.value) {
-            const foundSuites = suites.filter(suite => suite.name.toLowerCase().includes(e.target.value.toLowerCase()))
+        if (e.target.value && selectedSuiteForTreeView) {
+            const query = e.target.value.toLowerCase()
+            const foundSuites: treeSuite[] = []
+            const findSuitesByName = (childrenSuitesArr: treeSuite[]) => {
+                childrenSuitesArr.map((suite) => {
+                    if (suite.name.toLowerCase().includes(query)) {
+                        foundSuites.push(suite)
+                    }
+                    if (suite.children.length > 0) {
+                        findSuitesByName(suite.children)
+                    }
+                })
+            }
+            if (selectedSuiteForTreeView.name.toLowerCase().includes(query)) {
+                foundSuites.push(selectedSuiteForTreeView)
+            }
+            findSuitesByName(selectedSuiteForTreeView.children)
             const suitesIdArray: string[] = []
             let suitesHtmlElmArray: any[] = []
 
@@ -293,7 +307,7 @@ const FolderSuites = (props: {
         <div style={{
             height: "100%"
         }}>
-            {treeSuites !== undefined &&
+            {selectedSuiteForTreeView !== undefined &&
             <div style={{
                 height: "100%"
             }}>
@@ -341,7 +355,8 @@ const FolderSuites = (props: {
                             textAlign: "left",
                         }}
                     >
-                        <Suite key={treeSuites.id} row={treeSuites} nodeId={treeSuites.id}
+                        <Suite key={selectedSuiteForTreeView.id} row={selectedSuiteForTreeView}
+                               nodeId={selectedSuiteForTreeView.id}
                         />
                     </TreeView>
                 </div>

--- a/tms-ts/src/components/testcases/suites.component.tsx
+++ b/tms-ts/src/components/testcases/suites.component.tsx
@@ -80,7 +80,6 @@ const SuitesComponent: React.FC = () => {
     const [showCreationCase, setShowCreationCase] = useState(false)
     const [showCreationSuite, setShowCreationSuite] = useState(false)
     const [selected, setSelected] = React.useState<readonly string[]>([]);
-    const [suites, setSuites] = useState<suite []>([])
     const [treeSuites, setTreeSuites] = useState<treeSuite[]>([])
     const [infoCaseForEdit, setInfoCaseForEdit] = useState<myCase | null>(null)
     const [infoSuiteForEdit, setInfoSuiteForEdit] = useState<{ id: number, name: string } | null>(null)
@@ -102,8 +101,8 @@ const SuitesComponent: React.FC = () => {
     const [selectedSuiteForTreeView, setSelectedSuiteForTreeView] = useState<treeSuite | undefined>(undefined)
     const navigate = useNavigate()
     const memoizedValueFolderStructureOfSuites = useMemo(() =>
-            <FolderSuites treeSuites={selectedSuiteForTreeView} suites={suites}/>,
-        [suites, treeSuites, selectedSuiteForTreeView]);
+            <FolderSuites selectedSuiteForTreeView={selectedSuiteForTreeView}/>,
+        [treeSuites, selectedSuiteForTreeView]);
     const [countOfSuitesOnPage, setCountOfSuitesOnPage] = useState(parseInt(localStorage.getItem("countOfSuitesOnPage") ?? "20"));
     const start = 10
     const stop = 100
@@ -112,11 +111,6 @@ const SuitesComponent: React.FC = () => {
 
 
     useEffect(() => {
-        SuiteCaseService.getSuites().then((response) => {
-            setSuites(response.data)
-        }).catch((e) => {
-            console.log(e);
-        });
         SuiteCaseService.getTreeSuites().then((response) => {
             setTreeSuites(response.data)
         }).catch((e) => {
@@ -141,7 +135,7 @@ const SuitesComponent: React.FC = () => {
     }, [selectedSuiteId])
 
     const handleShowCreationCase = () => {
-        if (suites.length > 0 && selectedSuiteForTreeView !== undefined) {
+        if (selectedSuiteForTreeView !== undefined) {
             setShowCreationCase(true)
             setSelectedSuiteCome({id: selectedSuiteForTreeView.id, name: selectedSuiteForTreeView.name})
         }
@@ -177,7 +171,6 @@ const SuitesComponent: React.FC = () => {
                                                                         setShowCreationCase={setShowCreationCase}
                                                                         setShowCreationSuite={setShowCreationSuite}
                                                                         setSelectedSuiteCome={setSelectedSuiteCome}
-                                                                        suites={suites}
                                                                         selectedSuiteForTreeView={selectedSuiteForTreeView}
                                                                         setSelectedSuiteForTreeView={setSelectedSuiteForTreeView}
                                                                         setInfoCaseForEdit={setInfoCaseForEdit}
@@ -206,7 +199,7 @@ const SuitesComponent: React.FC = () => {
                             }
                         }} onClick={handleShowCreationCase}>Создать
                             тест-кейс</Button>
-                        <CreationCase show={showCreationCase} setShow={setShowCreationCase} suites={suites}
+                        <CreationCase show={showCreationCase} setShow={setShowCreationCase}
                                       selectedSuiteCome={selectedSuiteCome} setTreeSuites={setTreeSuites}
                                       infoCaseForEdit={infoCaseForEdit}
                                       setInfoCaseForEdit={setInfoCaseForEdit}
@@ -228,13 +221,13 @@ const SuitesComponent: React.FC = () => {
                         }
                     }} onClick={handleShowCreationSuite}>Создать
                         сьюту</Button>
-                    <CreationSuite show={showCreationSuite} setShow={setShowCreationSuite} suites={suites}
-                                   setSuites={setSuites}
+                    <CreationSuite show={showCreationSuite} setShow={setShowCreationSuite}
                                    selectedSuiteCome={selectedSuiteCome} setTreeSuites={setTreeSuites}
                                    setSelectedSuiteForTreeView={setSelectedSuiteForTreeView}
                                    selectedSuiteForTreeView={selectedSuiteForTreeView}
                                    infoSuiteForEdit={infoSuiteForEdit}
                                    setInfoSuiteForEdit={setInfoSuiteForEdit}
+                                   treeSuites={treeSuites}
                     />
                 </div>
                 {selectedSuiteForTreeView === undefined &&

--- a/tms-ts/src/components/testcases/table.suites.component.tsx
+++ b/tms-ts/src/components/testcases/table.suites.component.tsx
@@ -124,7 +124,7 @@ function Row(props: {
     setTreeSuites: (treeSuites: treeSuite[]) => void, selectedCases: number[], setSelectedCases: (cases: number[]) => void,
     setOpenDialogDeletion: (show: boolean) => void,
     setComponentForDeletion: (component: { type: string, id: number }) => void,
-    classesTableSuitesCases: any, setInfoSuiteForEdit: (suite: {id: number, name: string}) => void,
+    classesTableSuitesCases: any, setInfoSuiteForEdit: (suite: { id: number, name: string }) => void,
 }) {
     const {
         row,
@@ -199,9 +199,9 @@ function Row(props: {
                             {row.name}
                         </div>
                         <IconButton size={"small"} onClick={() => {
-                            SuiteCaseService.getSuiteById(row.id).then((response)=> {
-                                if (response.data.parent){
-                                    SuiteCaseService.getSuiteById(response.data.parent).then((response)=> {
+                            SuiteCaseService.getSuiteById(row.id).then((response) => {
+                                if (response.data.parent) {
+                                    SuiteCaseService.getSuiteById(response.data.parent).then((response) => {
                                         setSelectedSuiteCome({id: response.data.id, name: response.data.name})
                                         setShowCreationSuite(true)
                                     })
@@ -322,7 +322,7 @@ const TableSuites = (props: {
     selected: readonly string[], setSelected: (array: readonly string[]) => void,
     setShowCreationCase: (show: boolean) => void, setShowCreationSuite: (show: boolean) => void,
     setSelectedSuiteCome: (selectedSuite: { id: number, name: string } | null) => void,
-    suites: suite [], setInfoCaseForEdit: (myCase: myCase) => void, setInfoSuiteForEdit: (suite: {id: number, name: string}) => void,
+    setInfoCaseForEdit: (myCase: myCase) => void, setInfoSuiteForEdit: (suite: { id: number, name: string }) => void,
     setDetailedCaseInfo: (myCase: { show: boolean, myCase: myCase }) => void,
     detailedCaseInfo: { show: boolean, myCase: myCase }, lastEditCase: number,
     setLastEditCase: (id: number) => void,
@@ -334,7 +334,6 @@ const TableSuites = (props: {
     const {
         setShowCreationCase,
         setShowCreationSuite,
-        suites,
         setSelectedSuiteCome,
         setInfoCaseForEdit,
         setDetailedCaseInfo,
@@ -355,17 +354,31 @@ const TableSuites = (props: {
 
     const openAll = () => {
         let newMap = new Map()
-        suites.map((suite) => {
-            newMap.set(suite.id, true)
-        })
+        const setAllInTrue = (childrenSuitesArr: treeSuite[]) => {
+            childrenSuitesArr.map((suite) => {
+                newMap.set(suite.id, true)
+                if (suite.children.length > 0) {
+                    setAllInTrue(suite.children)
+                }
+            })
+        }
+        newMap.set(selectedSuiteForTreeView.id, true)
+        setAllInTrue(selectedSuiteForTreeView.children)
         setTreeSuitesOpenMap(newMap)
     }
 
     const closeAll = () => {
         let newMap = new Map()
-        suites.map((suite) => {
-            newMap.set(suite.id, false)
-        })
+        const setAllInFalse = (childrenSuitesArr: treeSuite[]) => {
+            childrenSuitesArr.map((suite) => {
+                newMap.set(suite.id, false)
+                if (suite.children.length > 0) {
+                    setAllInFalse(suite.children)
+                }
+            })
+        }
+        newMap.set(selectedSuiteForTreeView.id, false)
+        setAllInFalse(selectedSuiteForTreeView.children)
         setTreeSuitesOpenMap(newMap)
     }
     const classesTableSuitesCases = useStylesTestCases()
@@ -391,7 +404,7 @@ const TableSuites = (props: {
              classesTableSuitesCases={classesTableSuitesCases}
         />
         </tbody>
-    </table>, [suites, selectedSuiteForTreeView, treeSuitesOpenMap, selectedCases]);
+    </table>, [selectedSuiteForTreeView, treeSuitesOpenMap, selectedCases]);
     useEffect(() => {
         if (detailedCaseInfo.show) {
             if (shownCase.show && detailedCaseInfo.myCase.id === shownCase.myCaseId && lastEditCase !== detailedCaseInfo.myCase.id) {


### PR DESCRIPTION
I got rid of the use of suite variables in the code, which I received at the request of getSuites(). When creating suites in the select, you can select only those suites as parent suites that are "now on the screen".